### PR TITLE
Fix JDK 8 uninstall bug when installing MySQL JDBC package.

### DIFF
--- a/install_clouderamanagerserver.sh
+++ b/install_clouderamanagerserver.sh
@@ -87,6 +87,7 @@ if [ -z "$http_proxy" ]; then
 fi
 
 if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then
+  # Test to see if JDK 6 is present.
   if rpm -q jdk >/dev/null; then
     HAS_JDK=yes
   else
@@ -113,7 +114,9 @@ if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then
   else
     if [ "$INSTALLDB" == mysql ]; then
       yum -y -e1 -d1 install mysql-connector-java
-      if [ $HAS_JDK = no ]; then yum -y -e1 -d1 remove jdk; fi
+      # Removes JDK 6 if it snuck onto the system. Tests for the actual RPM
+      # named "jdk" to keep virtual packages from causing a JDK 8 uninstall.
+      if [ "$HAS_JDK" == no ] && rpm -q jdk >/dev/null; then yum -y -e1 -d1 remove jdk; fi
     elif [ "$INSTALLDB" == postgresql ]; then
       yum -y -e1 -d1 install postgresql-jdbc
     elif [ "$INSTALLDB" == oracle ]; then

--- a/install_jdbc.sh
+++ b/install_jdbc.sh
@@ -121,6 +121,7 @@ if [ -z "$INSTALLDB" ]; then
 fi
 
 if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then
+  # Test to see if JDK 6 is present.
   if rpm -q jdk >/dev/null; then
     HAS_JDK=yes
   else
@@ -129,7 +130,9 @@ if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then
   if [ "$INSTALLDB" == yes ]; then
     echo "** NOTICE: Installing mysql and postgresql JDBC drivers."
     yum -y -e1 -d1 install mysql-connector-java postgresql-jdbc
-    if [ $HAS_JDK == no ]; then yum -y -e1 -d1 remove jdk; fi
+    # Removes JDK 6 if it snuck onto the system. Tests for the actual RPM named
+    # "jdk" to keep virtual packages from causing a JDK 8 uninstall.
+    if [ "$HAS_JDK" == no ] && rpm -q jdk >/dev/null; then yum -y -e1 -d1 remove jdk; fi
   else
     if [ "$INSTALLDB" == mysql ]; then
       echo "** NOTICE: Installing mysql JDBC driver."
@@ -145,7 +148,9 @@ if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then
         ls -l /usr/share/java/*sql*
       else
         yum -y -e1 -d1 install mysql-connector-java
-        if [ $HAS_JDK == no ]; then yum -y -e1 -d1 remove jdk; fi
+	# Removes JDK 6 if it snuck onto the system. Tests for the actual RPM
+	# named "jdk" to keep virtual packages from causing a JDK 8 uninstall.
+        if [ "$HAS_JDK" == no ] && rpm -q jdk >/dev/null; then yum -y -e1 -d1 remove jdk; fi
       fi
     elif [ "$INSTALLDB" == postgresql ]; then
       echo "** NOTICE: Installing postgresql JDBC driver."


### PR DESCRIPTION
Oracle JDK 8 RPM jdk1.8.0_131-1.8.0_131-fcs.x86_64 has a virtual package named "jdk" that triggers this bug.