### PR TITLE
Enhancements18

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -26,7 +26,7 @@ MACHINE=cmserver
 
 scp -p -o StrictHostKeyChecking=no ${GITREPO}/api/install_dump_cm_config.sh \
   ${GITREPO}/api/dump_cm_config.sh ${MACHINE}:
-ssh -t $MACHINE 'sudo bash -x install_dump_cm_config.sh'
+ssh -t $MACHINE 'sudo bash -x install_dump_cm_config.sh -u admin -p admin -H localhost -P 7180'
 ```
 
 Grab the passwords that are output from the above command.

--- a/api/install_dump_cm_config.sh
+++ b/api/install_dump_cm_config.sh
@@ -117,6 +117,7 @@ if curl -s -X GET -u "admin:admin" http://${CMHOST}:${CMPORT}/api/${API}/users/$
   crontab /tmp/$$
   rm -f /tmp/$$
 else
-  echo "APIUSER ${APIUSER} already exists.  Exiting."
+  echo "WARNING: APIUSER ${APIUSER} already exists.  Exiting without installing crontab."
+  exit 2
 fi
 

--- a/api/install_dump_cm_config.sh
+++ b/api/install_dump_cm_config.sh
@@ -13,6 +13,39 @@
 # limitations under the License.
 #
 # Copyright Clairvoyant 2015
+#
+if [ $DEBUG ]; then set -x; fi
+#
+##### START CONFIG ###################################################
+
+APIUSER=api
+
+##### STOP CONFIG ####################################################
+PATH=/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin
+ADMINUSER="admin"
+ADMINPASS="admin"
+CMHOST="localhost"
+CMPORT=7180
+API="v5"
+
+# Function to print the help screen.
+print_help () {
+  echo "Usage:     $1 [-u <admin username>] [-p <admin password>] [-H <host>] [-P <port>]"
+  echo "           $1 [-h|--help]"
+  echo "           $1 [-v|--version]"
+  echo "defaults:  $1 -u admin -p admin -H localhost -P 7180"
+  echo ""
+  echo "   ex.     $1 -u userA -p mypass -P 7183"
+  exit 1
+}
+
+# Function to check for root priviledges.
+check_root () {
+  if [[ $(/usr/bin/id | awk -F= '{print $2}' | awk -F"(" '{print $1}' 2>/dev/null) -ne 0 ]]; then
+    echo "You must have root priviledges to run this program."
+    exit 2
+  fi
+}
 
 # Function to discover basic OS details.
 discover_os () {
@@ -38,6 +71,60 @@ discover_os () {
   fi
 }
 
+## If the variable DEBUG is set, then turn on tracing.
+## http://www.research.att.com/lists/ast-users/2003/05/msg00009.html
+#if [ $DEBUG ]; then
+#  # This will turn on the ksh xtrace option for mainline code
+#  set -x
+#
+#  # This will turn on the ksh xtrace option for all functions
+#  typeset +f |
+#  while read F junk
+#  do
+#    typeset -ft $F
+#  done
+#  unset F junk
+#fi
+
+# Process arguments.
+while [[ $1 = -* ]]; do
+  case $1 in
+    -u|--user)
+      shift
+      ADMINUSER=$1
+      ;;
+    -p|--password)
+      shift
+      ADMINPASS=$1
+      ;;
+    -H|--host)
+      shift
+      CMHOST=$1
+      ;;
+    -P|--port)
+      shift
+      CMPORT=$1
+      ;;
+    -h|--help)
+      print_help "$(basename "$0")"
+      ;;
+    -v|--version)
+      echo "Install cronjob to perform Cloudera Manager configuration backup."
+      exit 0
+      ;;
+    *)
+      print_help "$(basename "$0")"
+      ;;
+  esac
+  shift
+done
+
+# Check to see if we have the required parameters.
+if [[ -z "$ADMINUSER" || -z "$ADMINPASS" || -z "$CMHOST" || -z "$CMPORT" ]]; then print_help "$(basename "$0")"; fi
+
+# Lets not bother continuing unless we have the privs to do something.
+check_root
+
 echo "********************************************************************************"
 echo "*** $(basename $0)"
 echo "********************************************************************************"
@@ -48,11 +135,22 @@ if [ "$OS" != RedHatEnterpriseServer -a "$OS" != CentOS -a "$OS" != Debian -a "$
   exit 3
 fi
 
+if [ "$CMPORT" -eq 7183 ]; then
+  CMSCHEME=https
+  OPT="-k"
+else
+  CMSCHEME=http
+fi
+BASEURL=${CMSCHEME}://${CMHOST}:${CMPORT}
+
+if ! (exec 6<>/dev/tcp/${CMHOST}/${CMPORT}); then
+  echo "ERROR: cloudera-scm-server not listening on host: ${CMHOST} port: ${CMPORT}..."
+  exit 10
+fi
+
 if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then
   # https://discourse.criticalengineering.org/t/howto-password-generation-in-the-gnu-linux-cli/10
   PWCMD='< /dev/urandom tr -dc A-Za-z0-9 | head -c 20;echo'
-  #if ! rpm -q apg; then echo "Installing apg. Please wait...";yum -y -d1 -e1 install apg; fi
-  #if rpm -q apg; then export PWCMD='apg -a 1 -M NCL -m 20 -x 20 -n 1'; fi
   if ! rpm -q apg >/dev/null; then
     echo "Installing apg. Please wait..."
     yum -y -d1 -e1 install apg
@@ -73,28 +171,17 @@ elif [ "$OS" == Debian -o "$OS" == Ubuntu ]; then
   fi
 fi
 
-ADMINUSER=admin
-ADMINPASS=admin
-APIUSER=api
 APIPASS=`eval $PWCMD`
-CMHOST=localhost
-CMPORT=7180
-API=v5
 
-if ! (exec 6<>/dev/tcp/${CMHOST}/${CMPORT}); then
-  echo 'ERROR: cloudera-scm-server not listening...'
-  exit 1
-fi
-
-if curl -s -X GET -u "${ADMINUSER}:${ADMINPASS}" http://${CMHOST}:${CMPORT}/api/${API}/users/${APIUSER} | grep -q "does not exist"; then
-  curl -s -X POST -u "${ADMINUSER}:${ADMINPASS}" -H "content-type:application/json" -d \
+if curl -s $OPT -X GET -u "${ADMINUSER}:${ADMINPASS}" "${BASEURL}/api/${API}/users/${APIUSER}" | grep -q "does not exist"; then
+  curl -s $OPT -X POST -u "${ADMINUSER}:${ADMINPASS}" -H "content-type:application/json" -d \
   "{
     \"items\" : [ {
       \"name\" : \"$APIUSER\",
       \"password\" : \"$APIPASS\",
       \"roles\" : [ \"ROLE_ADMIN\" ]
     } ]
-  }" http://${CMHOST}:${CMPORT}/api/${API}/users
+  }" "${BASEURL}/api/${API}/users"
   echo ""
   echo "****************************************"
   echo "****************************************"
@@ -119,7 +206,7 @@ if curl -s -X GET -u "${ADMINUSER}:${ADMINPASS}" http://${CMHOST}:${CMPORT}/api/
   crontab /tmp/$$
   rm -f /tmp/$$
 else
-  echo "WARNING: APIUSER ${APIUSER} already exists.  Exiting without installing crontab."
-  exit 2
+  echo "ERROR: APIUSER ${APIUSER} already exists.  Exiting without installing crontab."
+  exit 11
 fi
 

--- a/api/install_dump_cm_config.sh
+++ b/api/install_dump_cm_config.sh
@@ -73,6 +73,8 @@ elif [ "$OS" == Debian -o "$OS" == Ubuntu ]; then
   fi
 fi
 
+ADMINUSER=admin
+ADMINPASS=admin
 APIUSER=api
 APIPASS=`eval $PWCMD`
 CMHOST=localhost
@@ -84,8 +86,8 @@ if ! (exec 6<>/dev/tcp/${CMHOST}/${CMPORT}); then
   exit 1
 fi
 
-if curl -s -X GET -u "admin:admin" http://${CMHOST}:${CMPORT}/api/${API}/users/${APIUSER} | grep -q "does not exist"; then
-  curl -s -X POST -u "admin:admin" -H "content-type:application/json" -d \
+if curl -s -X GET -u "${ADMINUSER}:${ADMINPASS}" http://${CMHOST}:${CMPORT}/api/${API}/users/${APIUSER} | grep -q "does not exist"; then
+  curl -s -X POST -u "${ADMINUSER}:${ADMINPASS}" -H "content-type:application/json" -d \
   "{
     \"items\" : [ {
       \"name\" : \"$APIUSER\",

--- a/director/install_clouderadirector.sh
+++ b/director/install_clouderadirector.sh
@@ -92,6 +92,12 @@ chmod 0640 /etc/cloudera-director-server/application.properties
 sed -i -e '/lp.encryption.twoWayCipher:/a\
 lp.encryption.twoWayCipher: desede' -e "/lp.encryption.twoWayCipherConfig:/a\
 lp.encryption.twoWayCipherConfig: `python -c 'import base64, os; print base64.b64encode(os.urandom(24))'`" /etc/cloudera-director-server/application.properties
+## https://www.cloudera.com/documentation/director/latest/topics/director_create_java_clusters.html
+#echo "Forcing use of JDK 8..."
+#sed -e '/^# lp.bootstrap.packages.javaPackage:/a\
+#lp.bootstrap.packages.cmJavaPackages: .*=oracle-j2sdk1.8\
+#lp.bootstrap.packages.defaultCmJavaPackage: oracle-j2sdk1.8' \
+#    -i /etc/cloudera-director-server/application.properties
 echo "Starting Director..."
 service cloudera-director-server start
 

--- a/evaluate.sh
+++ b/evaluate.sh
@@ -437,7 +437,7 @@ esac
 if [ "$OS" == RedHatEnterpriseServer ]; then
   echo "****************************************"
   echo "*** RedHat Subscription"
-  subscription-manager version
+  sudo -n /sbin/subscription-manager version
 fi
 
 #echo "****************************************"

--- a/evaluate.sh
+++ b/evaluate.sh
@@ -442,9 +442,10 @@ fi
 echo "****************************************"
 echo "*** Cloudera Software"
 if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then
-  rpm -qa ^cloudera\*
+  rpm -qa ^cloudera\* ^navencrypt\*
 elif [ "$OS" == Debian -o "$OS" == Ubuntu ]; then
   dpkg -l \*cloudera\* | awk '$1~/^ii$/{print $2"\t"$3"\t"$4}'
+  dpkg -l \*navencrypt\* | awk '$1~/^ii$/{print $2"\t"$3"\t"$4}'
 fi
 echo "*** Cloudera Hadoop Packages"
 if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then

--- a/evaluate.sh
+++ b/evaluate.sh
@@ -401,6 +401,8 @@ if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then
 elif [ "$OS" == Debian -o "$OS" == Ubuntu ]; then
   dpkg -l hadoop | awk '$1~/^ii$/{print $2"\t"$3"\t"$4}'
 fi
+echo "*** Cloudera Parcels"
+ls -l /opt/cloudera/parcels
 
 echo "****************************************"
 echo "*** Hortonworks Software"

--- a/evaluate.sh
+++ b/evaluate.sh
@@ -167,13 +167,6 @@ echo "** startup config:"
 grep swap /etc/fstab || echo "none"
 
 echo "****************************************"
-echo "*** JAVA_HOME"
-echo JAVA_HOME=$JAVA_HOME
-echo PATH=$PATH
-echo "** default java version:"
-java -version 2>&1 || ${JAVA_HOME}/java -version 2>&1
-
-echo "****************************************"
 echo "*** Firewall"
 echo "** running config:"
 IPT=$(sudo -n iptables -nL)
@@ -268,12 +261,55 @@ echo "** available entropy:"
 cat /proc/sys/kernel/random/entropy_avail
 
 echo "****************************************"
+echo "*** Java"
+echo "** installed Java(s):"
+if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then
+  rpm -qa | egrep 'jdk|jre|^java-|j2sdk' | sort
+elif [ "$OS" == Debian -o "$OS" == Ubuntu ]; then
+  dpkg -l \*jdk\* \*jre\* java-\* \*j2sdk\* oracle-java\* | awk '$1~/^ii$/{print $2"\t"$3"\t"$4}'
+fi
+# Which is our standard?
+echo "** which java:"
+which java
+echo "** default java version:"
+# https://stackoverflow.com/questions/7334754/correct-way-to-check-java-version-from-bash-script
+if type -p java >/dev/null; then
+  #echo "Java executable found in PATH."
+  _JAVA=java
+elif [ -n "$JAVA_HOME" ] && [ -x "${JAVA_HOME}/bin/java" ]; then
+  #echo "Java executable found in JAVA_HOME."
+  _JAVA="${JAVA_HOME}/bin/java"
+else
+  echo "Java not found."
+fi
+if [ -n "$_JAVA" ]; then
+  #java -version 2>&1 || ${JAVA_HOME}/java -version 2>&1
+  "$_JAVA" -version 2>&1
+  _JAVA_VERSION=$("$_JAVA" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+  _JAVA_VERSION_MAJ=$(echo "${_JAVA_VERSION}" | awk -F. '{print $1}')
+  _JAVA_VERSION_MIN=$(echo "${_JAVA_VERSION}" | awk -F. '{print $2}')
+  _JAVA_VERSION_PATCH=$(echo "${_JAVA_VERSION}" | awk -F. '{print $3}' | sed -e 's|_.*||')
+  _JAVA_VERSION_RELEASE=$(echo "${_JAVA_VERSION}" | awk -F_ '{print $2}')
+else
+  _JAVA_VERSION_MAJ=0
+  _JAVA_VERSION_MIN=0
+  _JAVA_VERSION_PATCH=0
+  _JAVA_VERSION_RELEASE=0
+fi
+
+echo "****************************************"
+echo "*** JAVA_HOME"
+echo JAVA_HOME=$JAVA_HOME
+echo PATH=$PATH
+
+echo "****************************************"
 echo "*** JCE"
 if which unzip >/dev/null 2>&1; then
   UNZIP=true
 else
   UNZIP=false
 fi
+_JCE_FOUND=false
 for _DIR in /usr/java/default/jre/lib/security \
             /usr/java/jdk1.6.0_31/jre/lib/security \
             /usr/java/jdk1.7.0_67-cloudera/jre/lib/security \
@@ -283,43 +319,58 @@ for _DIR in /usr/java/default/jre/lib/security \
             /usr/lib/jvm/default-java/jre/lib/security \
             /usr/lib/jvm/java-7-oracle/jre/lib/security \
             /usr/lib/jvm/java-8-oracle/jre/lib/security; do
-  if [ -d "$_DIR" ]; then
+  if [ -f "${_DIR}/local_policy.jar" ]; then
+    _JCE_FOUND=true
     if [ "$UNZIP" == true ]; then
       # http://harshj.com/checking-if-your-jre-has-the-unlimited-strength-policy-files-in-place/
-      unzip -c "${_DIR}"/local_policy.jar default_local.policy | grep -q javax.crypto.CryptoAllPermission && echo -n "unlimited" || echo -n "vanilla  "
+      unzip -c "${_DIR}"/local_policy.jar default_local.policy | grep -q javax.crypto.CryptoAllPermission && echo -n "unlimited         " || echo -n "vanilla           "
       echo " JCE in $_DIR"
     else
       #ls -l "${_DIR}"/*.jar
       sha1sum "${_DIR}"/*.jar
     fi
+  elif [ "${_JAVA_VERSION_MAJ}" -eq 1 ] && [ "${_JAVA_VERSION_MIN}" -eq 8 ] && [ "${_JAVA_VERSION_RELEASE}" -ge 151 ]; then
+  # https://www.cloudera.com/documentation/enterprise/release-notes/topics/rn_consolidated_pcm.html#jce
+  # Enabling Unlimited Strength Encryption for JDK 1.8.0_151 (and later)
+  #
+  # As of JDK 1.8.0_151, unlimited strength encryption can be enabled using the
+  # java.security file as documented in the JDK 1.8.0_151 release notes. You do
+  # not need to install the JCE policy files.
+  #
+  # As of JDK 1.8.0_161, unlimited strength encryption has been enabled by
+  # default. No further action is required.
+    _JCE_FOUND=true
+    if [ -f "${_DIR}"/java.security ]; then
+      if grep -q ^crypto.policy=unlimited "${_DIR}"/java.security; then
+        echo "unlimited built-in JCE in $_DIR"
+      elif grep -q ^crypto.policy=limited "${_DIR}"/java.security; then
+        echo "vanilla   built-in JCE in $_DIR"
+      else
+        if [ "${_JAVA_VERSION_RELEASE}" -ge 161 ]; then
+          echo "unlimited built-in JCE in $_DIR"
+        elif [ "${_JAVA_VERSION_RELEASE}" -ge 151 ]; then
+          echo "vanilla   built-in JCE in $_DIR"
+        fi
+      fi
+    fi
   fi
 done
+if [ "$_JCE_FOUND" == "false" ]; then
+  echo "JCE not found."
+fi
 
 echo "****************************************"
 echo "*** JDBC"
+echo "** JDBC packages:"
 if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then
   rpm -q mysql-connector-java postgresql-jdbc
 elif [ "$OS" == Debian -o "$OS" == Ubuntu ]; then
   dpkg -l libmysql-java libpostgresql-jdbc-java | awk '$1~/^ii$/{print $2"\t"$3"\t"$4}'
 fi
+echo "** JDBC files:"
 ls -l /usr/share/java/mysql-connector-java.jar
 ls -l /usr/share/java/oracle-connector-java.jar /usr/share/java/ojdbc?.jar
 ls -l /usr/share/java/sqlserver-connector-java.jar /usr/share/java/sqljdbc*.jar
-
-echo "****************************************"
-echo "*** Java"
-echo "** installed Java(s):"
-if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then
-  rpm -qa | egrep 'jdk|jre|^java-|j2sdk' | sort
-elif [ "$OS" == Debian -o "$OS" == Ubuntu ]; then
-  #dpkg -l | egrep 'jdk|jre|^java-|j2sdk'
-  dpkg -l \*jdk\* \*jre\* java-\* \*j2sdk\* oracle-java\* | awk '$1~/^ii$/{print $2"\t"$3"\t"$4}'
-fi
-echo "** default java version:"
-java -version 2>&1
-# Which is our standard?
-echo "** which java:"
-which java
 
 echo "****************************************"
 echo "*** Kerberos"

--- a/install_clouderamanagerserver.sh
+++ b/install_clouderamanagerserver.sh
@@ -44,20 +44,30 @@ discover_os () {
 
 _install_oracle_jdbc() {
   pushd $(dirname $0)
-  if [ ! -f ojdbc6.jar ]; then
-    echo "** NOTICE: ojdbc6.jar not found.  Please manually download from"
+  if [ ! -f ojdbc6.jar ] && [ ! -f ojdbc8.jar ]; then
+    echo "** NOTICE: ojdbc6.jar or ojdbc8.jar not found.  Please manually download from"
     echo "   http://www.oracle.com/technetwork/database/enterprise-edition/jdbc-112010-090769.html"
+    echo "   or"
+    echo "   http://www.oracle.com/technetwork/database/features/jdbc/jdbc-ucp-122-3110062.html"
     echo "   and place in the same directory as this script."
     exit 1
-  else
-    cp -p ojdbc6.jar /tmp/ojdbc6.jar
   fi
   if [ ! -d /usr/share/java ]; then
     install -o root -g root -m 0755 -d /usr/share/java
   fi
-  install -o root -g root -m 0644 /tmp/ojdbc6.jar /usr/share/java/
-  ln -sf ojdbc6.jar /usr/share/java/oracle-connector-java.jar
-  ls -l /usr/share/java/oracle-connector-java.jar /usr/share/java/ojdbc6.jar
+  if [ -f ojdbc6.jar ]; then
+    cp -p ojdbc6.jar /tmp/ojdbc6.jar
+    install -o root -g root -m 0644 /tmp/ojdbc6.jar /usr/share/java/
+    ln -sf ojdbc6.jar /usr/share/java/oracle-connector-java.jar
+    ls -l /usr/share/java/ojdbc6.jar
+  fi
+  if [ -f ojdbc8.jar ]; then
+    cp -p ojdbc8.jar /tmp/ojdbc8.jar
+    install -o root -g root -m 0644 /tmp/ojdbc8.jar /usr/share/java/
+    ln -sf ojdbc8.jar /usr/share/java/oracle-connector-java.jar
+    ls -l /usr/share/java/ojdbc8.jar
+  fi
+  ls -l /usr/share/java/oracle-connector-java.jar
   popd
 }
 

--- a/install_hortonworksambariserver.sh
+++ b/install_hortonworksambariserver.sh
@@ -46,21 +46,31 @@ discover_os () {
 }
 
 _install_oracle_jdbc() {
-  pushd "$(dirname "$0")"
-  if [ ! -f ojdbc6.jar ]; then
-    echo "** NOTICE: ojdbc6.jar not found.  Please manually download from"
+  pushd $(dirname $0)
+  if [ ! -f ojdbc6.jar ] && [ ! -f ojdbc8.jar ]; then
+    echo "** NOTICE: ojdbc6.jar or ojdbc8.jar not found.  Please manually download from"
     echo "   http://www.oracle.com/technetwork/database/enterprise-edition/jdbc-112010-090769.html"
+    echo "   or"
+    echo "   http://www.oracle.com/technetwork/database/features/jdbc/jdbc-ucp-122-3110062.html"
     echo "   and place in the same directory as this script."
     exit 1
-  else
-    cp -p ojdbc6.jar /tmp/ojdbc6.jar
   fi
   if [ ! -d /usr/share/java ]; then
     install -o root -g root -m 0755 -d /usr/share/java
   fi
-  install -o root -g root -m 0644 /tmp/ojdbc6.jar /usr/share/java/
-  ln -sf ojdbc6.jar /usr/share/java/oracle-connector-java.jar
-  ls -l /usr/share/java/oracle-connector-java.jar /usr/share/java/ojdbc6.jar
+  if [ -f ojdbc6.jar ]; then
+    cp -p ojdbc6.jar /tmp/ojdbc6.jar
+    install -o root -g root -m 0644 /tmp/ojdbc6.jar /usr/share/java/
+    ln -sf ojdbc6.jar /usr/share/java/oracle-connector-java.jar
+    ls -l /usr/share/java/ojdbc6.jar
+  fi
+  if [ -f ojdbc8.jar ]; then
+    cp -p ojdbc8.jar /tmp/ojdbc8.jar
+    install -o root -g root -m 0644 /tmp/ojdbc8.jar /usr/share/java/
+    ln -sf ojdbc8.jar /usr/share/java/oracle-connector-java.jar
+    ls -l /usr/share/java/ojdbc8.jar
+  fi
+  ls -l /usr/share/java/oracle-connector-java.jar
   popd
 }
 

--- a/install_jce.sh
+++ b/install_jce.sh
@@ -67,16 +67,20 @@ if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then
     unzip -o -j /tmp/jce_policy-6.zip -d /usr/java/jdk1.6.0_31/jre/lib/security/
   fi
 
-  if rpm -q oracle-j2sdk1.7 || test -d /usr/java/jdk1.7.0_*; then
+  if rpm -q oracle-j2sdk1.7 || rpm -qa | grep jdk1.7.0_ || test -d /usr/java/jdk1.7.0_*; then
     wget -c --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" \
       http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip -O /tmp/jce_policy-7.zip
-    unzip -o -j /tmp/jce_policy-7.zip -d /usr/java/jdk1.7.0_67-cloudera/jre/lib/security/
+    for _DIR in /usr/java/jdk1.7.0_*; do
+      unzip -o -j /tmp/jce_policy-7.zip -d "${_DIR}/jre/lib/security/"
+    done
   fi
 
-  if rpm -q oracle-j2sdk1.8 || test -d /usr/java/jdk1.8.0_*; then
+  if rpm -q oracle-j2sdk1.8 || rpm -q jdk1.8 || rpm -qa | grep jdk1.8.0_ || test -d /usr/java/jdk1.8.0_*; then
     wget -c --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" \
       http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -O /tmp/jce_policy-8.zip
-    unzip -o -j /tmp/jce_policy-8.zip -d /usr/java/jdk1.8.0_*/jre/lib/security/
+    for _DIR in /usr/java/jdk1.8.0_*; do
+      unzip -o -j /tmp/jce_policy-8.zip -d "${_DIR}/jre/lib/security/"
+    done
   fi
 elif [ "$OS" == Debian -o "$OS" == Ubuntu ]; then
   export DEBIAN_FRONTEND=noninteractive

--- a/install_jdbc.sh
+++ b/install_jdbc.sh
@@ -66,20 +66,30 @@ _jdk_major_version() {
 
 _install_oracle_jdbc() {
   pushd $(dirname $0)
-  if [ ! -f ojdbc6.jar ]; then
-    echo "** NOTICE: ojdbc6.jar not found.  Please manually download from"
+  if [ ! -f ojdbc6.jar ] && [ ! -f ojdbc8.jar ]; then
+    echo "** NOTICE: ojdbc6.jar or ojdbc8.jar not found.  Please manually download from"
     echo "   http://www.oracle.com/technetwork/database/enterprise-edition/jdbc-112010-090769.html"
+    echo "   or"
+    echo "   http://www.oracle.com/technetwork/database/features/jdbc/jdbc-ucp-122-3110062.html"
     echo "   and place in the same directory as this script."
     exit 1
-  else
-    cp -p ojdbc6.jar /tmp/ojdbc6.jar
   fi
   if [ ! -d /usr/share/java ]; then
     install -o root -g root -m 0755 -d /usr/share/java
   fi
-  install -o root -g root -m 0644 /tmp/ojdbc6.jar /usr/share/java/
-  ln -sf ojdbc6.jar /usr/share/java/oracle-connector-java.jar
-  ls -l /usr/share/java/oracle-connector-java.jar /usr/share/java/ojdbc6.jar
+  if [ -f ojdbc6.jar ]; then
+    cp -p ojdbc6.jar /tmp/ojdbc6.jar
+    install -o root -g root -m 0644 /tmp/ojdbc6.jar /usr/share/java/
+    ln -sf ojdbc6.jar /usr/share/java/oracle-connector-java.jar
+    ls -l /usr/share/java/ojdbc6.jar
+  fi
+  if [ -f ojdbc8.jar ]; then
+    cp -p ojdbc8.jar /tmp/ojdbc8.jar
+    install -o root -g root -m 0644 /tmp/ojdbc8.jar /usr/share/java/
+    ln -sf ojdbc8.jar /usr/share/java/oracle-connector-java.jar
+    ls -l /usr/share/java/ojdbc8.jar
+  fi
+  ls -l /usr/share/java/oracle-connector-java.jar
   popd
 }
 

--- a/install_jdk.sh
+++ b/install_jdk.sh
@@ -101,8 +101,8 @@ if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then
   elif [ "$USECLOUDERA" = 8 ]; then
     pushd /tmp
     wget -c --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" \
-      http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.rpm -O jdk-8u131-linux-x64.rpm
-    rpm -Uv jdk-8u131-linux-x64.rpm
+      http://download.oracle.com/otn-pub/java/jdk/8u172-b11/a58eab1ec242421181065cdc37240b08/jdk-8u172-linux-x64.rpm -O jdk-8u172-linux-x64.rpm
+    rpm -Uv jdk-8u172-linux-x64.rpm
     popd
   else
     echo "ERROR: Unknown Java version.  Please choose 7 or 8."

--- a/navencrypt/README.md
+++ b/navencrypt/README.md
@@ -78,7 +78,7 @@ DEVICE=/dev/sdb
 EMOUNTPOINT=/navencrypt/0
 
 scp -p -o StrictHostKeyChecking=no ${GITREPO}/navencrypt/navencrypt_prepare.sh ${HOST}:
-ssh -t $HOST "sudo bash navencrypt_prepare.sh --navpass $NAVPASS --device $DEVICE --mountpoint $EMOUNTPOINT"
+ssh -t $HOST "sudo bash navencrypt_prepare.sh --navpass $NAVPASS --device $DEVICE --emountpoint $EMOUNTPOINT"
 ```
 
 THESE SCRIPTS FORMAT DISKS, WIPE FILESYSTEMS, AND EAT BABIES.

--- a/navencrypt/navencrypt_prepare.sh
+++ b/navencrypt/navencrypt_prepare.sh
@@ -33,18 +33,18 @@ FORCE=no
 
 # Function to print the help screen.
 print_help () {
-  printf "Usage:  $1 --navpass <password> --device <device> --mountpoint <mountpoint> [--fstype <fstype>] [--mountoptions <options>]\n"
+  printf "Usage:  $1 --navpass <password> --device <device> --emountpoint <emountpoint> [--fstype <fstype>] [--mountoptions <options>]\n"
   printf "\n"
   printf "         -n|--navpass          Password used to encrypt the local Navigator Encrypt configuration.\n"
   printf "         -d|--device           Disk device to encrypt.  Device will be wiped.\n"
-  printf "         -m|--mountpoint       Mountpoint of the encrypted filesystem.\n"
+  printf "         -e|--emountpoint      Mountpoint of the encrypted filesystem.\n"
   printf "        [-t|--fstype]          Filesystem type.  Default is xfs.\n"
   printf "        [-o|--mountoptions]    Filesystem mount options.  Default is noatime.\n"
   printf "        [-f|--force]           Force wipe any existing data.\n"
   printf "        [-h|--help]\n"
   printf "        [-v|--version]\n"
   printf "\n"
-  printf "   ex.  $1 --navpass \"mypasssword\" --device /dev/sdb --mountpoint /navencrypt/2\n"
+  printf "   ex.  $1 --navpass \"mypasssword\" --device /dev/sdb --emountpoint /navencrypt/2\n"
   exit 1
 }
 
@@ -82,9 +82,9 @@ while [[ $1 = -* ]]; do
       shift
       DEVICE=$1
       ;;
-    -m|--mountpoint)
+    -e|--emountpoint)
       shift
-      MOUNTPOINT=$(echo $1 | sed -e 's|/$||')
+      EMOUNTPOINT=$(echo $1 | sed -e 's|/$||')
       ;;
     -t|--fstype)
       shift
@@ -117,7 +117,7 @@ echo "**************************************************************************
 # Check to see if we have no parameters.
 if [[ -z "$NAVPASS" ]]; then print_help "$(basename $0)"; fi
 if [[ -z "$DEVICE" ]]; then print_help "$(basename $0)"; fi
-if [[ -z "$MOUNTPOINT" ]]; then print_help "$(basename $0)"; fi
+if [[ -z "$EMOUNTPOINT" ]]; then print_help "$(basename $0)"; fi
 
 # Lets not bother continuing unless we have the privs to do something.
 check_root
@@ -166,14 +166,14 @@ if [ -f /etc/navencrypt/keytrustee/clientname ]; then
     if [ "$FORCE" == yes ]; then
       dd if=/dev/zero of=${DEVICE}${PART} ibs=1M count=1
     fi
-    mkdir -p -m 0755 $(dirname $MOUNTPOINT)
-    mkdir -p -m 0755 $MOUNTPOINT && \
-    chattr +i $MOUNTPOINT && \
+    mkdir -p -m 0755 $(dirname $EMOUNTPOINT)
+    mkdir -p -m 0755 $EMOUNTPOINT && \
+    chattr +i $EMOUNTPOINT && \
     printf '%s' $NAVPASS |
-    navencrypt-prepare -t $FSTYPE -o $FSMOUNTOPT --use-uuid ${DEVICE}${PART} $MOUNTPOINT -
+    navencrypt-prepare -t $FSTYPE -o $FSMOUNTOPT --use-uuid ${DEVICE}${PART} $EMOUNTPOINT -
     RETVAL=$?
     if [ "$RETVAL" -ne 0 ]; then
-      echo "** ERROR: Could not format ${DEVICE} for ${MOUNTPOINT}."
+      echo "** ERROR: Could not format ${DEVICE} for ${EMOUNTPOINT}."
       exit $RETVAL
     fi
   else

--- a/services/README.sssd.md
+++ b/services/README.sssd.md
@@ -49,3 +49,19 @@ scp -p -o StrictHostKeyChecking=no ${GITREPO}/services/install_sssd-ldap.sh ${HO
 ssh -t $HOST "sudo bash -x install_sssd-ldap.sh --ldapserver $LDAP --suffix $BASE"
 ```
 
+## Authorization
+
+In order to restrict which users can authenticate to the system (for example via SSH) SSSD can be configured for [client-side access control](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/windows_integration_guide/realmd-logins) in order [to only allow certain users or groups](https://www.freedesktop.org/software/realmd/docs/realm.html).
+
+### Active Directory
+
+Users:
+```
+realm permit user@example.com
+realm permit 'AD.EXAMPLE.COM\user'
+```
+
+Groups:
+```
+realm permit -g group@example.com
+```

--- a/services/README.sssd.md
+++ b/services/README.sssd.md
@@ -19,9 +19,10 @@ Pass `--help` to each script to see the options.
 ```
 GITREPO=~/git/teamclairvoyant/bash
 ADDOMAIN=HADOOP.COM
+PASSWORD=hahahahaha
 
 scp -p -o StrictHostKeyChecking=no ${GITREPO}/services/install_sssd-ad.sh ${HOST}:
-ssh -t $HOST "sudo bash -x install_sssd-ad.sh --domain $ADDOMAIN"
+ssh -t $HOST "sudo bash -x install_sssd-ad.sh --domain $ADDOMAIN --batch <<< $PASSWORD"
 ```
 
 ### LDAP and Kerberos

--- a/services/install_haproxy.sh
+++ b/services/install_haproxy.sh
@@ -17,7 +17,7 @@
 exit 1
 
 echo "********************************************************************************"
-echo "*** $(basename $0)"
+echo "*** $(basename "$0")"
 echo "********************************************************************************"
 echo "Installing HAproxy..."
 yum -y -d1 -e1 install haproxy
@@ -28,6 +28,7 @@ cat <<EOF >/etc/haproxy/haproxy.cfg
 # CLAIRVOYANT
 # http://gethue.com/hadoop-tutorial-how-to-distribute-impala-query-load/
 # https://www.cloudera.com/documentation/enterprise/5-8-x/topics/impala_proxy.html
+# https://www.cloudera.com/documentation/enterprise/latest/topics/hue_sec_ha.html
 global
     log 127.0.0.1 local2
     chroot /var/lib/haproxy
@@ -51,7 +52,8 @@ defaults
 
 ## Setup for Oozie.
 #frontend oozie
-#    bind 0.0.0.0:11000
+#    bind 0.0.0.0:11000 # http
+##   bind 0.0.0.0:11443 # https
 #    mode http
 #    default_backend oozie_servers
 #    option httplog
@@ -100,7 +102,8 @@ defaults
 
 ## Setup for Solr.
 #frontend solr
-#    bind 0.0.0.0:8983
+#    bind 0.0.0.0:8983 # http
+##   bind 0.0.0.0:8985 # https
 #    mode http
 #    default_backend solr_servers
 #    option httplog

--- a/services/install_sssd-ad.sh
+++ b/services/install_sssd-ad.sh
@@ -160,16 +160,16 @@ EOF
   realm join $_DOMAIN_LOWER $OPTS || exit $?
 
   sed -e '/^use_fully_qualified_names .*/d' \
-      -e "/^\[domain/a\
-use_fully_qualified_names = False" -i /etc/sssd/sssd.conf
-  sed -e '/^ default_ccache_name = .*/d' \
-      -e '/^ # We have to use FILE:.*/d' \
-      -e '/^ # https://community.hortonworks.com/.*/d' \
-      -e '/^ #default_ccache_name = FILE:/tmp/krb5cc_%{uid}$/d' \
-      -e "/^ rdns = /a\
- # We have to use FILE: until JVM can support something better.
- # https://community.hortonworks.com/questions/11288/kerberos-cache-in-ipa-redhat-idm-keyring-solved.html
- #default_ccache_name = FILE:/tmp/krb5cc_%{uid}" -i /etc/sssd/sssd.conf
+      -e '/^\[domain/a\
+use_fully_qualified_names = False' -i /etc/sssd/sssd.conf
+  sed -e '/^default_ccache_name = .*/d' \
+      -e '/^# We have to use FILE:.*/d' \
+      -e '/^# https:\/\/community.hortonworks.com\/.*/d' \
+      -e '/^#default_ccache_name = FILE:\/tmp\/krb5cc_%{uid}$/d' \
+      -e '/^\[domain/a\
+# We have to use FILE: until JVM can support something better.\
+# https://community.hortonworks.com/questions/11288/kerberos-cache-in-ipa-redhat-idm-keyring-solved.html\
+#default_ccache_name = FILE:/tmp/krb5cc_%{uid}' -i /etc/sssd/sssd.conf
   service sssd restart
 
 elif [ \( "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS \) -a "$OSREL" == 6 ]; then

--- a/services/install_sssd-ad.sh
+++ b/services/install_sssd-ad.sh
@@ -33,6 +33,7 @@ print_help () {
   echo "        $1 [-u|--user <User name to use for enrollment>]"
   echo "        $1 [-o|--computer-ou <Computer OU DN to join>]"
   echo "        $1 [-i|--automatic-id-mapping] # Turn off automatic id mapping"
+  echo "        $1 [-b|--batch] # Do not prompt for passwords"
   echo "        $1 [-h|--help]"
   echo "        $1 [-v|--version]"
   echo "   ex.  $1"
@@ -109,6 +110,10 @@ while [[ $1 = -* ]]; do
       shift
       _ID="--automatic-id-mapping=no"
       ;;
+    -b|--batch)
+      shift
+      _BATCH7="--unattended"
+      ;;
     -h|--help)
       print_help "$(basename $0)"
       ;;
@@ -145,7 +150,7 @@ check_root
 echo "Installing SSSD for Active Directory..."
 if [ \( "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS \) -a "$OSREL" == 7 ]; then
   # EL7
-  OPTS="$_USER $_OU7 $_ID"
+  OPTS="$_USER $_OU7 $_ID $_BATCH7"
   echo "** Installing software."
   yum $YUMOPTS install sssd adcli realmd PackageKit
 

--- a/tls/README.md
+++ b/tls/README.md
@@ -191,3 +191,19 @@ MACHINE=somehost
 scp -p ${GITREPO}/tls/configure_openldap_tls.sh ${MACHINE}:
 ssh -t $MACHINE 'sudo bash ./configure_openldap_tls.sh'
 ```
+
+## Configure Cloudera Director for TLS
+
+Configure an existing [Cloudera Director](https://www.cloudera.com/products/product-components/cloudera-director.html) server installation to use the Cloudera TLS certificates.  This script depends on having followed the [Install a TLS Signed Certificate](#install-a-tls-signed-certificate) instructions.  The configuration also disables SSLv2, SSLv3, TLSv1.0, and TLSv1.1 protocols.
+
+### Installation
+
+```
+GITREPO=~/git/teamclairvoyant/bash
+MACHINE=somehost
+CMPASS=$CMPASS
+
+scp -p ${GITREPO}/tls/configure_clouderadirector_tls.sh ${MACHINE}:
+ssh -t $MACHINE "sudo bash ./configure_clouderadirector_tls.sh $CMPASS"
+```
+

--- a/tls/configure_clouderadirector_tls.sh
+++ b/tls/configure_clouderadirector_tls.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright Clairvoyant 2018
+
+# ARGV:
+# 1 - JKS store password - required
+
+SP="$1"
+KP="$SP"
+
+if [ -z "$SP" ]; then
+  echo "ERROR: Missing keystore password."
+  exit 2
+fi
+if [ -z "$KP" ]; then
+  echo "ERROR: Missing private key password."
+  exit 3
+fi
+
+echo "********************************************************************************"
+echo "*** $(basename "$0")"
+echo "********************************************************************************"
+chmod 0440 /opt/cloudera/security/jks/localhost-keystore.jks
+chown root:cloudera-director /opt/cloudera/security/jks/localhost-keystore.jks
+
+# https://www.cloudera.com/documentation/director/latest/topics/director_tls_enable.html#concept_odg_qbv_gbb
+echo "Configuring Cloudera Director to use TLS..."
+sed -e '/^# CLAIRVOYANT TLS START$/,/^# CLAIRVOYANT TLS END$/d' \
+    -e "/server.ssl.key-store:/a\\
+# CLAIRVOYANT TLS START\\
+server.ssl.key-store: /opt/cloudera/security/jks/localhost-keystore.jks\\
+server.ssl.key-store-password: $SP\\
+server.ssl.key-store-type: JKS\\
+server.ssl.key-password: $KP\\
+server.ssl.enabled-protocols: TLSv1.2\\
+# CLAIRVOYANT TLS END" \
+    -i /etc/cloudera-director-server/application.properties
+echo "Restarting Director..."
+service cloudera-director-server restart
+

--- a/tls/generate_csr.sh
+++ b/tls/generate_csr.sh
@@ -21,7 +21,7 @@
 # 4 - Extra parameters for keytool (ie Subject Alternative Name (SAN)) - optional
 
 echo "********************************************************************************"
-echo "*** $(basename $0)"
+echo "*** $(basename "$0")"
 echo "********************************************************************************"
 #"CN=cmhost.sec.cloudera.com,OU=Support,O=Cloudera,L=Denver,ST=Colorado,C=US"
 DN="$1"
@@ -46,44 +46,64 @@ if [ -n "$EXT" ]; then
   EXT="-ext $EXT"
 fi
 
-echo "Generating TLS CSRs..."
+echo "Generating TLS CSR..."
 if [ -f /etc/profile.d/jdk.sh ]; then
+  # shellcheck source=/dev/null
   . /etc/profile.d/jdk.sh
 elif [ -f /etc/profile.d/java.sh ]; then
+  # shellcheck source=/dev/null
   . /etc/profile.d/java.sh
 fi
 
+if [ -f /opt/cloudera/security/jks/localhost-keystore.jks ]; then
+  echo "ERROR: Keystore already exists.  Exiting..."
+  exit 1
+fi
 keytool -genkeypair -alias localhost -keyalg RSA -sigalg SHA256withRSA \
--keystore /opt/cloudera/security/jks/localhost-keystore.jks \
--keysize 2048 -dname "$DN" -storepass $SP -keypass $KP
-
+ -keystore /opt/cloudera/security/jks/localhost-keystore.jks \
+ -keysize 2048 -dname "$DN" -storepass "$SP" -keypass "$KP"
 chmod 0440 /opt/cloudera/security/jks/localhost-keystore.jks
 chown root:cloudera-scm /opt/cloudera/security/jks/localhost-keystore.jks
 
+if [ -f /opt/cloudera/security/x509/localhost.csr ]; then
+  echo "ERROR: CSR already exists.  Exiting..."
+  exit 2
+fi
 # https://www.cloudera.com/documentation/enterprise/5-9-x/topics/cm_sg_create_deploy_certs.html#concept_frd_1px_nw
 # X509v3 Extended Key Usage:
 #   TLS Web Server Authentication, TLS Web Client Authentication
+# shellcheck disable=SC2086
 keytool -certreq -alias localhost \
--keystore /opt/cloudera/security/jks/localhost-keystore.jks \
--file /opt/cloudera/security/x509/localhost.csr -storepass $SP \
--keypass $KP -ext EKU=serverAuth,clientAuth -ext KU=digitalSignature,keyEncipherment $EXT
+ -keystore /opt/cloudera/security/jks/localhost-keystore.jks \
+ -file /opt/cloudera/security/x509/localhost.csr -storepass "$SP" \
+ -keypass "$KP" -ext EKU=serverAuth,clientAuth -ext KU=digitalSignature,keyEncipherment $EXT
 
 rm -f /tmp/localhost-keystore.p12.$$
-
 keytool -importkeystore -srckeystore /opt/cloudera/security/jks/localhost-keystore.jks \
--srcstorepass $SP -srckeypass $KP -destkeystore /tmp/localhost-keystore.p12.$$ \
--deststoretype PKCS12 -srcalias localhost -deststorepass $SP -destkeypass $KP
-
-openssl pkcs12 -in /tmp/localhost-keystore.p12.$$ -passin pass:$KP -nocerts \
--out /opt/cloudera/security/x509/localhost.e.key -passout pass:$KP
-
-openssl rsa -in /opt/cloudera/security/x509/localhost.e.key \
--passin pass:$KP -out /opt/cloudera/security/x509/localhost.key
-
-chmod 0400 /opt/cloudera/security/x509/localhost.e.key /opt/cloudera/security/x509/localhost.key
-
+ -srcstorepass "$SP" -srckeypass "$KP" -destkeystore /tmp/localhost-keystore.p12.$$ \
+ -deststoretype PKCS12 -srcalias localhost -deststorepass "$SP" -destkeypass "$KP"
+if [ -f /opt/cloudera/security/x509/localhost.e.key ]; then
+  echo "ERROR: Encrypted Key already exists.  Exiting..."
+  rm -f /tmp/localhost-keystore.p12.$$
+  exit 3
+fi
+openssl pkcs12 -in /tmp/localhost-keystore.p12.$$ -passin "pass:$KP" -nocerts \
+ -out /opt/cloudera/security/x509/localhost.e.key -passout "pass:$KP"
+chmod 0400 /opt/cloudera/security/x509/localhost.e.key
 rm -f /tmp/localhost-keystore.p12.$$
 
+if [ -f /opt/cloudera/security/x509/localhost.key ]; then
+  echo "ERROR: Key already exists.  Exiting..."
+  exit 4
+fi
+openssl rsa -in /opt/cloudera/security/x509/localhost.e.key \
+ -passin "pass:$KP" -out /opt/cloudera/security/x509/localhost.key
+chmod 0400 /opt/cloudera/security/x509/localhost.key
+
+if [ -f /etc/cloudera-scm-agent/agentkey.pw ]; then
+  echo "ERROR: Agent PW already exists.  Exiting..."
+  exit 5
+fi
 install -o root -g root -m 0755 -d /etc/cloudera-scm-agent
 install -o root -g root -m 0600 /dev/null /etc/cloudera-scm-agent/agentkey.pw
 echo "$SP" >/etc/cloudera-scm-agent/agentkey.pw

--- a/tls/install_rootCA.sh
+++ b/tls/install_rootCA.sh
@@ -43,8 +43,7 @@ echo "*** $(basename $0)"
 echo "********************************************************************************"
 # Check to see if we are on a supported OS.
 discover_os
-if [ "$OS" != RedHatEnterpriseServer -a "$OS" != CentOS ]; then
-#if [ "$OS" != RedHatEnterpriseServer -a "$OS" != CentOS -a "$OS" != Debian -a "$OS" != Ubuntu ]; then
+if [ "$OS" != RedHatEnterpriseServer -a "$OS" != CentOS -a "$OS" != Debian -a "$OS" != Ubuntu ]; then
   echo "ERROR: Unsupported OS."
   exit 3
 fi
@@ -80,6 +79,12 @@ if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then
     update-ca-trust extract
   fi
 elif [ "$OS" == Debian -o "$OS" == Ubuntu ]; then
-  :
+  pushd /opt/cloudera/security/CAcerts/
+  for SRC in *.pem; do
+    DST=$(echo "$SRC" | sed 's|pem$|crt|')
+    cp -p "/opt/cloudera/security/CAcerts/${SRC}" "/usr/local/share/ca-certificates/${DST}"
+  done
+  popd
+  update-ca-certificates
 fi
 


### PR DESCRIPTION
* Better configurability for api/install_dump_cm_config.sh.
* Add "realm permit" examples.
* Make the CM admin user and password into variables.
* Deal with JCE being built-in to newer JDKs.
* Deal with wildcard directories in JCE installation.
* Deal with JCE being built-in to newer JDKs.
* Update to Oracle JDK 8u172.
* Support Oracle 12.2 ojdbc8.jar JDBC driver.
* Add reference to https ports.
* Add tls/configure_clouderadirector_tls.sh.
* Add error messages and pass shellcheck.
* Add commented code to force deployment of JDK 8.
* Check for parcels.
* Add unattended/batch option to install_sssd-ad.sh.
* subscription-manager requires root access.
* Fix sed modifications to /etc/sssd/sssd.conf.
* Exit with error is API user exists.
* Support Debian/Ubuntu in tls/install_rootCA.sh.
* Add support for Director TLS to database.