### PR TITLE
Enhancements19

### DIFF
--- a/evaluate.sh
+++ b/evaluate.sh
@@ -84,8 +84,15 @@ echo
 sudo -n lvs
 echo "** Filesystems:"
 df -h -t ext2 -t ext3 -t ext4 -t xfs
-echo "** Network interfaces:"
+echo "** Network interfaces (raw):"
 ip addr
+echo "** Network interfaces:"
+for _NIC in $(ls /sys/class/net/ | grep -v ^lo$); do
+  _IP=$(ip addr show dev $_NIC)
+  echo "$_IP" | awk '/inet/{print "'${_NIC}' : IP:",$2}'
+  echo "$_IP" | awk '/mtu/{print "'${_NIC}' : MTU:",$5}'
+  ethtool $_NIC 2>/dev/null | grep -E 'Speed:|Duplex:|Port:' | sed "s|^[[:space:]]*|${_NIC} : |g"
+done
 echo "** Network routes:"
 ip route
 echo "** Network Bonding:"

--- a/evaluate.sh
+++ b/evaluate.sh
@@ -449,10 +449,9 @@ fi
 echo "****************************************"
 echo "*** Cloudera Software"
 if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then
-  rpm -qa ^cloudera\* ^navencrypt\*
+  rpm -qa ^cloudera\* ^navencrypt\* \*keytrustee\*
 elif [ "$OS" == Debian -o "$OS" == Ubuntu ]; then
-  dpkg -l \*cloudera\* | awk '$1~/^ii$/{print $2"\t"$3"\t"$4}'
-  dpkg -l \*navencrypt\* | awk '$1~/^ii$/{print $2"\t"$3"\t"$4}'
+  dpkg -l \*cloudera\* \*navencrypt\* \*keytrustee\* | awk '$1~/^ii$/{print $2"\t"$3"\t"$4}'
 fi
 echo "*** Cloudera Hadoop Packages"
 if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then

--- a/install_jce.sh
+++ b/install_jce.sh
@@ -95,13 +95,13 @@ fi
 
 if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then
   if rpm -q jdk || test -d /usr/java/jdk1.6.0_*; then
-    wget -c --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" \
+    wget -nv -c --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" \
       http://download.oracle.com/otn-pub/java/jce_policy/6/jce_policy-6.zip -O /tmp/jce_policy-6.zip
     unzip -o -j /tmp/jce_policy-6.zip -d /usr/java/jdk1.6.0_31/jre/lib/security/
   fi
 
   if rpm -q oracle-j2sdk1.7 || rpm -qa | grep jdk1.7.0_ || test -d /usr/java/jdk1.7.0_*; then
-    wget -c --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" \
+    wget -nv -c --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" \
       http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip -O /tmp/jce_policy-7.zip
     for _DIR in /usr/java/jdk1.7.0_*; do
       unzip -o -j /tmp/jce_policy-7.zip -d "${_DIR}/jre/lib/security/"
@@ -115,7 +115,7 @@ if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then
     exit 0
   fi
   if rpm -q oracle-j2sdk1.8 || rpm -q jdk1.8 || rpm -qa | grep jdk1.8.0_ || test -d /usr/java/jdk1.8.0_*; then
-    wget -c --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" \
+    wget -nv -c --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" \
       http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -O /tmp/jce_policy-8.zip
     for _DIR in /usr/java/jdk1.8.0_*; do
       unzip -o -j /tmp/jce_policy-8.zip -d "${_DIR}/jre/lib/security/"
@@ -124,7 +124,7 @@ if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then
 elif [ "$OS" == Debian -o "$OS" == Ubuntu ]; then
   export DEBIAN_FRONTEND=noninteractive
   if dpkg -l oracle-j2sdk1.7 >/dev/null || test -d /usr/lib/jvm/java-7-oracle-cloudera; then
-    wget -c --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" \
+    wget -nv -c --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" \
       http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip -O /tmp/jce_policy-7.zip
     unzip -o -j /tmp/jce_policy-7.zip -d /usr/lib/jvm/java-7-oracle-cloudera/jre/lib/security/
   fi

--- a/install_jdk.sh
+++ b/install_jdk.sh
@@ -94,13 +94,15 @@ if [ "$OS" == RedHatEnterpriseServer -o "$OS" == CentOS ]; then
     ln -s $TARGET /usr/java/default
   elif [ "$USECLOUDERA" = 7 ]; then
     pushd /tmp
-    wget -c --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" \
+    echo "*** Downloading Oracle JDK 7u80..."
+    wget -nv -c --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" \
       http://download.oracle.com/otn/java/jdk/7u80-b15/jdk-7u80-linux-x64.rpm -O jdk-7u80-linux-x64.rpm
     rpm -Uv jdk-7u80-linux-x64.rpm
     popd
   elif [ "$USECLOUDERA" = 8 ]; then
     pushd /tmp
-    wget -c --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" \
+    echo "*** Downloading Oracle JDK 8u181..."
+    wget -nv -c --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" \
       http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/jdk-8u181-linux-x64.rpm -O jdk-8u181-linux-x64.rpm
     rpm -Uv jdk-8u181-linux-x64.rpm
     popd

--- a/navencrypt/navencrypt_acl.sh
+++ b/navencrypt/navencrypt_acl.sh
@@ -102,5 +102,8 @@ if [ -f /etc/navencrypt/keytrustee/clientname ]; then
   navencrypt acl --add --rule="ALLOW @* * *"
   printf '%s' $NAVPASS | \
   navencrypt acl --list --all
+else
+  printf "** WARNING: This host is not yet registered.  Skipping..."
+  exit 3
 fi
 

--- a/navencrypt/navencrypt_move.sh
+++ b/navencrypt/navencrypt_move.sh
@@ -116,10 +116,21 @@ set -u
 umask 022
 
 if [ -f /etc/navencrypt/keytrustee/clientname ]; then
-  if [ ! -d $EMOUNTPOINT ]; then
-    echo "Moving data from ${MOUNTPOINT} to ${EMOUNTPOINT} for encryption..."
-    printf '%s' $NAVPASS |
-    navencrypt-move encrypt @${CATEGORY} $MOUNTPOINT $EMOUNTPOINT
+  if [ -d $MOUNTPOINT ]; then
+    if [ -d $EMOUNTPOINT ]; then
+      echo "Moving data from ${MOUNTPOINT} to ${EMOUNTPOINT} for encryption..."
+      printf '%s' $NAVPASS |
+      navencrypt-move encrypt @${CATEGORY} $MOUNTPOINT $EMOUNTPOINT
+    else
+      printf "** ERROR: Destination mountpoint ${EMOUNTPOINT} is not a directory. Exiting..."
+      exit 5
+    fi
+  else
+    printf "** ERROR: Source mountpoint ${MOUNTPOINT} is not a directory. Exiting..."
+    exit 4
   fi
+else
+  printf "** WARNING: This host is not yet registered.  Skipping..."
+  exit 3
 fi
 

--- a/tls/configure_jdk_tlsv1.2.sh
+++ b/tls/configure_jdk_tlsv1.2.sh
@@ -22,6 +22,8 @@ if [ -f /etc/profile.d/jdk.sh ]; then
   . /etc/profile.d/jdk.sh
 elif [ -f /etc/profile.d/java.sh ]; then
   . /etc/profile.d/java.sh
+elif [ -d /usr/java/default ]; then
+  JAVA_HOME=/usr/java/default
 fi
 
 if [ -z "${JAVA_HOME}" ]; then echo "ERROR: \$JAVA_HOME is not set."; exit 10; fi

--- a/tls/copy_cert-trustee.sh
+++ b/tls/copy_cert-trustee.sh
@@ -18,7 +18,11 @@ echo "**************************************************************************
 echo "*** $(basename $0)"
 echo "********************************************************************************"
 echo "Copying Keytrustee TLS certs and keys..."
-if [ ! -d /var/lib/keytrustee/.keytrustee/.ssl-orig/ ]; then
+if [ ! -d /var/lib/keytrustee/.keytrustee/.ssl/ ]; then
+  install -m 0700 -o keytrustee -g keytrustee -d /var/lib/keytrustee
+  install -m 0700 -o keytrustee -g keytrustee -d /var/lib/keytrustee/.keytrustee
+  install -m 0700 -o keytrustee -g keytrustee -d /var/lib/keytrustee/.keytrustee/.ssl
+elif [ ! -d /var/lib/keytrustee/.keytrustee/.ssl-orig/ ]; then
   cp -a /var/lib/keytrustee/.keytrustee/.ssl/ /var/lib/keytrustee/.keytrustee/.ssl-orig/
 fi
 cat /opt/cloudera/security/CAcerts/ca.cert.pem /opt/cloudera/security/CAcerts/intermediate.cert.pem >/opt/cloudera/security/x509/ca-chain.cert.pem

--- a/tls/install_rootCA.sh
+++ b/tls/install_rootCA.sh
@@ -53,6 +53,8 @@ if [ -f /etc/profile.d/jdk.sh ]; then
   . /etc/profile.d/jdk.sh
 elif [ -f /etc/profile.d/java.sh ]; then
   . /etc/profile.d/java.sh
+elif [ -d /usr/java/default ]; then
+  JAVA_HOME=/usr/java/default
 fi
 
 if [ -z "${JAVA_HOME}" ]; then echo "ERROR: \$JAVA_HOME is not set."; exit 10; fi

--- a/tls/install_rootCA.sh
+++ b/tls/install_rootCA.sh
@@ -60,6 +60,7 @@ fi
 if [ -z "${JAVA_HOME}" ]; then echo "ERROR: \$JAVA_HOME is not set."; exit 10; fi
 
 if [ ! -f ${JAVA_HOME}/jre/lib/security/jssecacerts ]; then
+  #TODO: On el7: /usr/java/default/jre/lib/security/cacerts -> /etc/pki/java/cacerts
   /bin/cp -p ${JAVA_HOME}/jre/lib/security/cacerts ${JAVA_HOME}/jre/lib/security/jssecacerts
 fi
 keytool -importcert -file /opt/cloudera/security/CAcerts/ca.cert.pem -alias CAcert -keystore ${JAVA_HOME}/jre/lib/security/jssecacerts -storepass changeit -noprompt -trustcacerts


### PR DESCRIPTION
* Set $JAVA_HOME if /usr/java/default exists.
* Create keytrustee directories if they do not exist.
* Better error handling in NavEnc scripts.
* Include reporting on keytrustee packages in evaluate.sh.
* Print better NIC info in evaluate.sh.
* Create less verbose output when downloading the Oracle JDK.