### PR TITLE
Enhancements24

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ for HOST in `cat HOSTLIST`; do
   sudo bash $BOPT ./disable_thp.sh; \
   sudo bash $BOPT ./install_ntp.sh; \
   sudo bash $BOPT ./install_nscd.sh; \
-  sudo bash $BOPT ./install_jdk.sh --jdktype oracle --jdkversion 8; \
+  sudo bash $BOPT ./install_jdk.sh --jdktype openjdk --jdkversion 8; \
   sudo bash $BOPT ./configure_javahome.sh; \
   sudo bash $BOPT ./install_jce.sh; \
   sudo bash $BOPT ./install_krb5.sh; \

--- a/disable_thp.sh
+++ b/disable_thp.sh
@@ -97,6 +97,8 @@ if [ "$OS" == RedHatEnterpriseServer ] || [ "$OS" == CentOS ]; then
     echo 'echo never >/sys/kernel/mm/transparent_hugepage/enabled' >>/etc/rc.d/rc.local
     chmod +x /etc/rc.d/rc.local
     systemctl start rc-local
+    sleep 2
+    systemctl restart rc-local
   fi
 elif [ "$OS" == Debian ] || [ "$OS" == Ubuntu ]; then
   echo never >/sys/kernel/mm/transparent_hugepage/defrag

--- a/install_chrony.sh
+++ b/install_chrony.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright Clairvoyant 2018
+
+# Function to discover basic OS details.
+discover_os() {
+  if command -v lsb_release >/dev/null; then
+    # CentOS, Ubuntu, RedHatEnterpriseServer, Debian, SUSE LINUX
+    # shellcheck disable=SC2034
+    OS=$(lsb_release -is)
+    # CentOS= 6.10, 7.2.1511, Ubuntu= 14.04, RHEL= 6.10, 7.5, SLES= 11
+    # shellcheck disable=SC2034
+    OSVER=$(lsb_release -rs)
+    # 7, 14
+    # shellcheck disable=SC2034
+    OSREL=$(echo "$OSVER" | awk -F. '{print $1}')
+    # Ubuntu= trusty, wheezy, CentOS= Final, RHEL= Santiago, Maipo, SLES= n/a
+    # shellcheck disable=SC2034
+    OSNAME=$(lsb_release -cs)
+  else
+    if [ -f /etc/redhat-release ]; then
+      if [ -f /etc/centos-release ]; then
+        # shellcheck disable=SC2034
+        OS=CentOS
+        # 7.5.1804.4.el7.centos, 6.10.el6.centos.12.3
+        # shellcheck disable=SC2034
+        OSVER=$(rpm -qf /etc/centos-release --qf='%{VERSION}.%{RELEASE}\n' | awk -F. '{print $1"."$2}')
+        # shellcheck disable=SC2034
+        OSREL=$(rpm -qf /etc/centos-release --qf='%{VERSION}\n')
+      else
+        # shellcheck disable=SC2034
+        OS=RedHatEnterpriseServer
+        # 7.5, 6Server
+        # shellcheck disable=SC2034
+        OSVER=$(rpm -qf /etc/redhat-release --qf='%{VERSION}\n')
+        if [ "$OSVER" == "6Server" ]; then
+          # shellcheck disable=SC2034
+          OSVER=$(rpm -qf /etc/redhat-release --qf='%{RELEASE}\n' | awk -F. '{print $1"."$2}')
+          # shellcheck disable=SC2034
+          OSNAME=Santiago
+        else
+          # shellcheck disable=SC2034
+          OSNAME=Maipo
+        fi
+        # shellcheck disable=SC2034
+        OSREL=$(echo "$OSVER" | awk -F. '{print $1}')
+      fi
+    elif [ -f /etc/SuSE-release ]; then
+      if grep -q "^SUSE Linux Enterprise Server" /etc/SuSE-release; then
+        OS="SUSE LINUX"
+      fi
+      # shellcheck disable=SC2034
+      OSVER=$(rpm -qf /etc/SuSE-release --qf='%{VERSION}\n' | awk -F. '{print $1}')
+      # shellcheck disable=SC2034
+      OSREL=$(rpm -qf /etc/SuSE-release --qf='%{VERSION}\n' | awk -F. '{print $1}')
+      # shellcheck disable=SC2034
+      OSNAME="n/a"
+    fi
+  fi
+}
+
+is_virtual() {
+  grep -Eqi 'VirtualBox|VMware|Parallel|Xen|innotek|QEMU|Virtual Machine' /sys/devices/virtual/dmi/id/*
+  return $?
+}
+
+echo "********************************************************************************"
+echo "*** $(basename "$0")"
+echo "********************************************************************************"
+# Check to see if we are on a supported OS.
+discover_os
+if [ "$OS" != RedHatEnterpriseServer ] && [ "$OS" != CentOS ] && [ "$OS" != Debian ] && [ "$OS" != Ubuntu ]; then
+  echo "ERROR: Unsupported OS."
+  exit 3
+fi
+
+echo "Installing Chrony NTP..."
+if [ "$OS" == RedHatEnterpriseServer ] || [ "$OS" == CentOS ]; then
+  yum -y -e1 -d1 remove ntp*
+  yum -y -e1 -d1 install chrony
+  service chronyd start
+  chkconfig chronyd on
+elif [ "$OS" == Debian ] || [ "$OS" == Ubuntu ]; then
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get -y -q remove ntp
+  apt-get -y -q install chrony
+  service chrony start
+  update-rc.d chrony defaults
+fi
+

--- a/install_jdk.sh
+++ b/install_jdk.sh
@@ -269,7 +269,7 @@ elif [ "$JDK_TYPE" == "oracle" ]; then
       cd /tmp || exit
       echo "*** Downloading Oracle JDK 8u202..."
       wget --connect-timeout=5 --tries=5 -nv -c --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" \
-        https://download.oracle.com/otn-pub/java/jdk/8u202-b08/1961070e4c9b4e26a04e7f5a083f551e/jdk-8u202-linux-x64.rpm -O jdk-8u202-linux-x64.rpm
+        http://archive.clairvoyantsoft.com/oracle_java/8/rpm/x86_64/jdk-8u202-linux-x64.rpm -O jdk-8u202-linux-x64.rpm
       rpm -Uv jdk-8u202-linux-x64.rpm
       ;;
     *)
@@ -293,16 +293,21 @@ elif [ "$JDK_TYPE" == "oracle" ]; then
       apt-get -y -q install oracle-java7-set-default
       ;;
     8)
-      #mkdir -p /var/cache/oracle-jdk8-installer
-      #mv jdk-8u*-linux-x64.tar.gz /var/cache/oracle-jdk8-installer/
-      if ! command -v add-apt-repository >/dev/null; then
-        apt-get -y -q install software-properties-common
-      fi
-      add-apt-repository -y ppa:webupd8team/java
-      apt-get -y -qq update
       echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-      apt-get -y -q install oracle-java8-installer
-      apt-get -y -q install oracle-java8-set-default
+      wget --connect-timeout=5 --tries=5 -nv -c --no-cookies --no-check-certificate \
+        http://archive.clairvoyantsoft.com/oracle_java/8/deb/oracle-java8-installer_8u201-2~clairvoyant~1_all.deb \
+        -O oracle-java8-installer_8u201-2~clairvoyant~1_all.deb
+      wget --connect-timeout=5 --tries=5 -nv -c --no-cookies --no-check-certificate \
+        http://archive.clairvoyantsoft.com/oracle_java/8/deb/oracle-java8-set-default_8u201-2~clairvoyant~1_all.deb \
+        -O oracle-java8-set-default_8u201-2~clairvoyant~1_all.deb
+      if [ "$OSNAME" == "trusty" ]; then
+        apt-get -y -q install gsfonts gsfonts-x11 java-common libfontenc1 libxfont1 x11-common xfonts-encodings xfonts-utils
+        dpkg -i ./oracle-java8-installer_8u201-2~clairvoyant~1_all.deb
+        dpkg -i ./oracle-java8-set-default_8u201-2~clairvoyant~1_all.deb
+      else
+        apt -y -q -o Dpkg::Progress-Fancy="0" install ./oracle-java8-installer_8u201-2~clairvoyant~1_all.deb
+        apt -y -q -o Dpkg::Progress-Fancy="0" install ./oracle-java8-set-default_8u201-2~clairvoyant~1_all.deb
+      fi
       ;;
     *)
       echo "ERROR: Unknown Java version.  Please choose 7 or 8."

--- a/install_jdk.sh
+++ b/install_jdk.sh
@@ -257,43 +257,28 @@ elif [ "$JDK_TYPE" == "oracle" ]; then
   echo "Installing Oracle JDK ${JDK_VERSION} ..."
   if [ "$OS" == RedHatEnterpriseServer ] || [ "$OS" == CentOS ]; then
     case "$JDK_VERSION" in
-    7)
-      # TODO: No longer works.  Oracle now requires login.
-      cd /tmp || exit
-      echo "*** Downloading Oracle JDK 7u80..."
-      wget --connect-timeout=5 --tries=5 -nv -c --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" \
-        http://download.oracle.com/otn/java/jdk/7u80-b15/jdk-7u80-linux-x64.rpm -O jdk-7u80-linux-x64.rpm
-      rpm -Uv jdk-7u80-linux-x64.rpm
-      ;;
     8)
       cd /tmp || exit
       echo "*** Downloading Oracle JDK 8u202..."
-      wget --connect-timeout=5 --tries=5 -nv -c --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" \
-        http://archive.clairvoyantsoft.com/oracle_java/8/rpm/x86_64/jdk-8u202-linux-x64.rpm -O jdk-8u202-linux-x64.rpm
+      wget --connect-timeout=5 --tries=5 -nv -c --no-cookies --no-check-certificate \
+        http://archive.clairvoyantsoft.com/oracle_java/8/rpm/x86_64/jdk-8u202-linux-x64.rpm \
+        -O jdk-8u202-linux-x64.rpm
       rpm -Uv jdk-8u202-linux-x64.rpm
       ;;
     *)
-      echo "ERROR: Unknown Java version.  Please choose 7 or 8."
+      echo "ERROR: Unknown Java version.  Please choose 8."
       exit 11
       ;;
     esac
   elif [ "$OS" == Debian ] || [ "$OS" == Ubuntu ]; then
     export DEBIAN_FRONTEND=noninteractive
     case "$JDK_VERSION" in
-    7)
-      #mkdir -p /var/cache/oracle-jdk7-installer
-      #mv jdk-7u*-linux-x64.tar.gz /var/cache/oracle-jdk7-installer/
-      if ! command -v add-apt-repository >/dev/null; then
-        apt-get -y -q install software-properties-common
-      fi
-      add-apt-repository -y ppa:webupd8team/java
-      apt-get -y -qq update
-      echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-      apt-get -y -q install oracle-java7-installer
-      apt-get -y -q install oracle-java7-set-default
-      ;;
     8)
       echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
+      #mkdir -p /var/cache/oracle-jdk8-installer
+      #wget --connect-timeout=5 --tries=5 -nv -c --no-cookies --no-check-certificate \
+      #  http://archive.clairvoyantsoft.com/oracle_java/8/tar/jdk-8u201-linux-x64.tar.gz \
+      #  -O /var/cache/oracle-jdk8-installer/jdk-8u201-linux-x64.tar.gz
       wget --connect-timeout=5 --tries=5 -nv -c --no-cookies --no-check-certificate \
         http://archive.clairvoyantsoft.com/oracle_java/8/deb/oracle-java8-installer_8u201-2~clairvoyant~1_all.deb \
         -O oracle-java8-installer_8u201-2~clairvoyant~1_all.deb
@@ -310,7 +295,7 @@ elif [ "$JDK_TYPE" == "oracle" ]; then
       fi
       ;;
     *)
-      echo "ERROR: Unknown Java version.  Please choose 7 or 8."
+      echo "ERROR: Unknown Java version.  Please choose 8."
       exit 11
       ;;
     esac

--- a/install_jdk.sh
+++ b/install_jdk.sh
@@ -238,6 +238,7 @@ if [ "$JDK_TYPE" == "cloudera" ]; then
         RETVAL=$?
         if [ "$RETVAL" -ne 0 ]; then
           echo "** ERROR: Could not download https://archive.cloudera.com/cm5/${OS_LOWER}/${OSNAME}/amd64/cm/cloudera.list"
+          rm -f /etc/apt/sources.list.d/cloudera-jdk.list
           exit 5
         fi
         chown root:root /etc/apt/sources.list.d/cloudera-jdk.list
@@ -256,6 +257,7 @@ if [ "$JDK_TYPE" == "cloudera" ]; then
         RETVAL=$?
         if [ "$RETVAL" -ne 0 ]; then
           echo "** ERROR: Could not download https://archive.cloudera.com/cm6/${SCMVERSION}/${OS_LOWER}${OSVER_NUMERIC}/apt/cloudera-manager.list"
+          rm -f /etc/apt/sources.list.d/cloudera-jdk.list
           exit 7
         fi
         chown root:root /etc/apt/sources.list.d/cloudera-jdk.list

--- a/install_jdk.sh
+++ b/install_jdk.sh
@@ -15,10 +15,6 @@
 #
 # Copyright Clairvoyant 2015
 
-# ARGV:
-# 1 - Which major JDK version to install. If empty, install JDK 7 from Cloudera. - optional
-# 2 - SCM version - optional
-
 # Note:
 # If you do not want to download the JDK multiple times or access to
 # download.oracle.com is blocked, you can place the manually downloaded JDK RPM
@@ -31,8 +27,7 @@ if [ -n "$DEBUG" ]; then set -x; fi
 
 ##### STOP CONFIG ####################################################
 PATH=/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin
-JDK_TYPE=cloudera
-JDK_VERSION=7
+JDK_VERSION=null
 SCMVERSION=6.2.0
 
 # Function to print the help screen.
@@ -41,7 +36,6 @@ print_help() {
   echo ""
   echo "        $1 -t|--jdktype       <cloudera|oracle|openjdk>"
   echo "        $1 [-j|--jdkversion]  <version>"
-  echo "        $1 [-c|--cmversion]   <version>"
   echo "        $1 [-h|--help]"
   echo "        $1 [-v|--version]"
   echo ""
@@ -142,10 +136,6 @@ while [[ $1 = -* ]]; do
       shift
       JDK_VERSION=$1
       ;;
-    -c|--cmversion)
-      shift
-      SCMVERSION=$1
-      ;;
     -h|--help)
       print_help "$(basename "$0")"
       ;;
@@ -171,7 +161,6 @@ if [ "$OS" != RedHatEnterpriseServer ] && [ "$OS" != CentOS ] && [ "$OS" != Debi
 fi
 
 # Check to see if we have the required parameters.
-#if [ -z "$JDK_TYPE" ] || [ -z "$JDK_VERSION" ]; then print_help "$(basename "$0")"; fi
 if [ "$JDK_TYPE" != "cloudera" ] && [ "$JDK_TYPE" != "oracle" ] && [ "$JDK_TYPE" != "openjdk" ]; then
   echo "** ERROR: --jdktype must be one of cloudera, oracle, or openjdk."
   echo ""
@@ -182,14 +171,6 @@ fi
 check_root
 
 # main
-# Backwards support of the old script.  See ARGV above.
-USECLOUDERA=$1
-if [ -n "$USECLOUDERA" ]; then
-  JDK_TYPE=oracle
-  JDK_VERSION=$USECLOUDERA
-fi
-SCMVERSION=$2
-
 PROXY=$(grep -Eh '^ *http_proxy=http|^ *https_proxy=http' /etc/profile.d/*)
 eval "$PROXY"
 export http_proxy

--- a/install_ntp.sh
+++ b/install_ntp.sh
@@ -106,6 +106,7 @@ if [ "$OS" == RedHatEnterpriseServer ] || [ "$OS" == CentOS ]; then
     # https://www.centos.org/forums/viewtopic.php?f=47&t=47626
     systemctl disable chronyd.service
   fi
+  yum -y -e1 -d1 remove chrony
   yum -y -e1 -d1 install ntp
   if is_virtual; then
     tinker_ntp.conf
@@ -114,6 +115,7 @@ if [ "$OS" == RedHatEnterpriseServer ] || [ "$OS" == CentOS ]; then
   chkconfig ntpd on
 elif [ "$OS" == Debian ] || [ "$OS" == Ubuntu ]; then
   export DEBIAN_FRONTEND=noninteractive
+  apt-get -y -q remove chrony
   apt-get -y -q install ntp
   if is_virtual; then
     tinker_ntp.conf

--- a/services/install_airflow.sh
+++ b/services/install_airflow.sh
@@ -242,17 +242,15 @@ if [ "$OS" == RedHatEnterpriseServer ] || [ "$OS" == CentOS ]; then
   fi
 
   echo "** Installing Airflow."
-  pip "$PIPOPTS" install airflow"${VERSION}"
-  # Fix a bug in celery 4
-  pip "$PIPOPTS" install 'celery<4'
-  pip "$PIPOPTS" install 'airflow[celery]'
+  pip "$PIPOPTS" install apache-airflow"${VERSION}"
+  pip "$PIPOPTS" install 'apache-airflow[celery]'
 
   if [ "$DB_TYPE" == "mysql" ]; then
     if [ -z "$DB_PORT" ]; then DB_PORT=$MYSQL_PORT; fi
     #####
     echo "** Installing Airflow[mysql]."
     yum -y -e1 -d1 install mysql-devel
-    pip "$PIPOPTS" install 'airflow[mysql]'
+    pip "$PIPOPTS" install 'apache-airflow[mysql]'
     DBCONNSTRING="mysql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/airflow"
 
   elif [ "$DB_TYPE" == "postgresql" ]; then
@@ -260,25 +258,25 @@ if [ "$OS" == RedHatEnterpriseServer ] || [ "$OS" == CentOS ]; then
     #####
     echo "** Installing Airflow[postgres]."
     yum -y -e1 -d1 install postgresql-devel
-    pip "$PIPOPTS" install 'airflow[postgres]'
+    pip "$PIPOPTS" install 'apache-airflow[postgres]'
     DBCONNSTRING="postgresql+psycopg2://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/airflow"
   fi
 
   #####
   echo "** Installing Airflow[kerberos]."
-  pip "$PIPOPTS" install 'airflow[kerberos]'
+  pip "$PIPOPTS" install 'apache-airflow[kerberos]'
   yum -y -e1 -d1 install libffi-devel
   echo "** Installing Airflow[crypto]."
-  pip "$PIPOPTS" install 'airflow[crypto]'
-  #pip "$PIPOPTS" install 'airflow[jdbc]'
+  pip "$PIPOPTS" install 'apache-airflow[crypto]'
+  #pip "$PIPOPTS" install 'apache-airflow[jdbc]'
   echo "** Installing Airflow[hive]."
-  pip "$PIPOPTS" install 'airflow[hive]'
-  #pip "$PIPOPTS" install 'airflow[hdfs]'
-  #pip "$PIPOPTS" install 'airflow[ldap]'
-  pip "$PIPOPTS" install 'airflow[password]'
+  pip "$PIPOPTS" install 'apache-airflow[hive]'
+  #pip "$PIPOPTS" install 'apache-airflow[hdfs]'
+  #pip "$PIPOPTS" install 'apache-airflow[ldap]'
+  pip "$PIPOPTS" install 'apache-airflow[password]'
   echo "** Installing Airflow[rabbitmq]."
-  pip "$PIPOPTS" install 'airflow[rabbitmq]'
-  #pip "$PIPOPTS" install 'airflow[s3]'
+  pip "$PIPOPTS" install 'apache-airflow[rabbitmq]'
+  #pip "$PIPOPTS" install 'apache-airflow[s3]'
 
   echo "** Installing Airflow configs."
   install -o root -g airflow -m0750 -d /var/lib/airflow

--- a/services/install_haproxy.sh
+++ b/services/install_haproxy.sh
@@ -150,6 +150,7 @@ defaults
 
 # Setup for beeswax (impala-shell) or original ODBC driver.
 # For JDBC or ODBC version 2.x driver, use port 21050 instead of 21000.
+# Set Hue "server_conn_timeout = 1 hour" to match the HAproxy timeout.
 listen impala-shell
     bind 0.0.0.0:21000
     timeout client 1h


### PR DESCRIPTION
Fix Oracle JDK installation:
* Remove `--cmversion` and backward support of the old script.
* Add support for Cloudera's Oracle JDK 8.
* Remove Oracle JDK 7 install.
* Download the Oracle JDK from archive.clairvoyantsoft.com.

Other:
* Activate THP settings on el7 during install.
* Update to use the new apache-airflow package name.
* Remove chrony when installing NTPd and add `install_chrony.sh`.